### PR TITLE
Added install & uninstall blocks to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
 # Comment/uncomment the following line to disable/enable debugging
 DEBUG = y
-
+MODULE_NAME = hid-acer
+KVER = $(shell uname -r)
+MODDESTDIR = /lib/modules/$(KVER)/kernel/drivers/hid/
 
 # Add your debugging flag (or not) to CFLAGS
 ifeq ($(DEBUG),y)
@@ -33,6 +35,13 @@ clean:
 depend .depend dep:
 	$(CC) $(CFLAGS) -M *.c > .depend
 
+install:
+	install -p -m 644 $(MODULE_NAME).ko  $(MODDESTDIR)
+	/sbin/depmod -a ${KVER}
+
+uninstall:
+	rm -f $(MODDESTDIR)/$(MODULE_NAME).ko
+	/sbin/depmod -a ${KVER}
 
 ifeq (.depend,$(wildcard .depend))
 include .depend


### PR DESCRIPTION
I tested it on Acer Switch 10; If driver is installed like this, there is no need to run ./installdriver.sh manually.
