### PR TITLE
Reused KVER variable in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ obj-m	:= hid-acer.o
 
 else
 
-KERNELDIR ?= /lib/modules/$(shell uname -r)/build
+KERNELDIR ?= /lib/modules/$(KVER)/build
 PWD       := $(shell pwd)
 
 default:


### PR DESCRIPTION
When the variable is reused it will be simpler to build/install the module for a different kernel version
